### PR TITLE
Fix url for BIP44

### DIFF
--- a/bip-p2sh-accounts.mediawiki
+++ b/bip-p2sh-accounts.mediawiki
@@ -92,5 +92,5 @@ To derive the P2SH address from the above calculated public key, we use the enca
 * [[bip-0016.mediawiki|BIP16 - Pay to Script Hash]]
 * [[bip-0032.mediawiki|BIP32 - Hierarchical Deterministic Wallets]]
 * [[bip-0043.mediawiki|BIP43 - Purpose Field for Deterministic Wallets]]
-* [[bip-0043.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]
+* [[bip-0044.mediawiki|BIP44 - Multi-Account Hierarchy for Deterministic Wallets]]
 * [[bip-0141.mediawiki|BIP141 - Segregated Witness (Consensus layer)]]


### PR DESCRIPTION
Fixes typo in url for BIP44
